### PR TITLE
Feature/update cert class for api v1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This started as sort of a labor of love/learning exercise, and sort of blossomed
 
 2) I am not affiliated with Pure Storage, beyond the fact that my company uses their product.
 
-3) While all of the classes exist, currently only up to API version 1.11 is supported.
+3) While all of the classes exist, currently only up to API version 1.12 is 'officially' supported- meaning it may work on newer versions, but I can't verify since I've only been able to develop against versions 1.12 and lower.
 
 ## Requirements
 
@@ -18,6 +18,11 @@ To be captain obvious, this does require you have access to a Pure Storage array
 This library requires you use Ruby 2.3 or above.
 
 # Usage
+
+## Installation
+```
+gem install purest
+```
 
 ## Configuration
 
@@ -34,7 +39,7 @@ end
 ```
 
 ## API options
-First: Authentication and session management is handled behind the scenes, you just need to supply your username/password in the configuration block (as shown in the example above). That's it.
+First: Authentication and session management are handled behind the scenes, you just need to supply your username/password in the configuration block (as shown in the example above). That's it.
 
 Second: The various class methods of this gem turn the provided options into HTTP parameters, and are
 named accordingly. For instance, ```Purest::Volume.get({:snap: true})``` translates

--- a/lib/purest/cert.rb
+++ b/lib/purest/cert.rb
@@ -2,9 +2,9 @@
 
 module Purest
   class Cert < Purest::APIMethods
-    @access_methods = %i[get update]
+    @access_methods = %i[get create update delete]
 
-    GET_PARAMS = %i[certificate common_name country email
+    GET_PARAMS = %i[ca_certificate certificate common_name country email
                     intermediate_certificate locality organization
                     organizational_unit state].freeze
 
@@ -16,7 +16,15 @@ module Purest
       end
     end
 
+    def create(options = nil)
+      super(options, 'cert')
+    end
+
     def update(options = nil)
+      super(options, 'cert')
+    end
+
+    def delete(options = nil)
       super(options, 'cert')
     end
   end

--- a/spec/cert_spec.rb
+++ b/spec/cert_spec.rb
@@ -9,38 +9,101 @@ describe Purest::Cert do
     allow_any_instance_of(Purest::Cert).to receive(:authenticated?).and_return(true)
   end
   describe '#get' do
-    context 'when listing certificate attributes' do
-      it 'gets to the correct url' do
-        stub_request(:get, "#{Purest.configuration.url}/api/1.11/cert")
-          .with(
-            headers: {
-              'Accept' => '*/*',
-              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-              'User-Agent' => 'Faraday v0.15.2'
-            }
-          )
-          .to_return(status: 200, body: JSON.generate([]), headers: {})
-        cert = Purest::Cert.get
+    context 'on api v1.11 or lower' do
+      context 'when listing certificate attributes' do
+        it 'gets to the correct url' do
+          stub_request(:get, "#{Purest.configuration.url}/api/1.11/cert")
+            .with(
+              headers: {
+                'Accept' => '*/*',
+                'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                'User-Agent' => 'Faraday v0.15.2'
+              }
+            )
+            .to_return(status: 200, body: JSON.generate([]), headers: {})
+          cert = Purest::Cert.get
+        end
+      end
+      context 'when exporting the current certificate' do
+        it 'gets to the correct url' do
+          stub_request(:get, "#{Purest.configuration.url}/api/1.11/cert?certificate=true")
+            .with(
+              headers: {
+                'Accept' => '*/*',
+                'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                'User-Agent' => 'Faraday v0.15.2'
+              }
+            )
+            .to_return(status: 200, body: JSON.generate([]), headers: {})
+          cert = Purest::Cert.get(certificate: true)
+        end
+      end
+      context 'when generating a CSR' do
+        it 'gets to the correct url' do
+          stub_request(:get, "#{Purest.configuration.url}/api/1.11/cert/certificate_signing_request?common_name=host.example.com")
+            .with(
+              headers: {
+                'Accept' => '*/*',
+                'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                'User-Agent' => 'Faraday v0.15.2'
+              }
+            )
+            .to_return(status: 200, body: JSON.generate([]), headers: {})
+          cert = Purest::Cert.get(csr: true, common_name: 'host.example.com')
+        end
       end
     end
-    context 'when exporting the current certificate' do
-      it 'gets to the correct url' do
-        stub_request(:get, "#{Purest.configuration.url}/api/1.11/cert?certificate=true")
-          .with(
-            headers: {
-              'Accept' => '*/*',
-              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-              'User-Agent' => 'Faraday v0.15.2'
-            }
-          )
-          .to_return(status: 200, body: JSON.generate([]), headers: {})
-        cert = Purest::Cert.get(certificate: true)
+    context 'on api v1.12 or higher' do
+      context 'when listing attributes about a specific certificate' do
+        it 'gets to the correct url' do
+          stub_request(:get, "#{Purest.configuration.url}/api/1.11/cert/dummy_cert")
+            .with(
+              headers: {
+                'Accept' => '*/*',
+                'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                'User-Agent' => 'Faraday v0.15.2'
+              }
+            )
+            .to_return(status: 200, body: JSON.generate([]), headers: {})
+          cert = Purest::Cert.get(name: 'dummy_cert')
+        end
+      end
+      context 'when exporting a named certificate' do
+        it 'gets to the correct url' do
+          stub_request(:get, "#{Purest.configuration.url}/api/1.11/cert/dummy_cert?certificate=true")
+            .with(
+              headers: {
+                'Accept' => '*/*',
+                'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                'User-Agent' => 'Faraday v0.15.2'
+              }
+            )
+            .to_return(status: 200, body: JSON.generate([]), headers: {})
+          cert = Purest::Cert.get(certificate: true, name: 'dummy_cert')
+        end
+      end
+      context 'when creating a CSR for a named certificate' do
+        it 'gets to the correct url' do
+          stub_request(:get, "#{Purest.configuration.url}/api/1.11/cert/certificate_signing_request/dummy_cert")
+            .with(
+              headers: {
+                'Accept' => '*/*',
+                'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                'User-Agent' => 'Faraday v0.15.2'
+              }
+            )
+            .to_return(status: 200, body: JSON.generate([]), headers: {})
+          cert = Purest::Cert.get(csr: true, name: 'dummy_cert')
+        end
       end
     end
-    context 'when generating a CSR' do
-      it 'gets to the correct url' do
-        stub_request(:get, "#{Purest.configuration.url}/api/1.11/cert/certificate_signing_request?common_name=host.example.com")
+  end
+  describe '#post' do
+    context 'when creating a new certificate by name' do
+      it 'puts to the correct URL with some cool params' do
+        stub_request(:post, "#{Purest.configuration.url}/api/1.11/cert/new_cert")
           .with(
+            body: '{"name":"new_cert","self_signed":true,"common_name":"host.example.com","state":"FL"}',
             headers: {
               'Accept' => '*/*',
               'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
@@ -48,7 +111,7 @@ describe Purest::Cert do
             }
           )
           .to_return(status: 200, body: JSON.generate([]), headers: {})
-        cert = Purest::Cert.get(csr: true, common_name: 'host.example.com')
+          cert = Purest::Cert.create(name: 'new_cert', self_signed: true, common_name: 'host.example.com', state: 'FL')
       end
     end
   end
@@ -66,6 +129,22 @@ describe Purest::Cert do
           )
           .to_return(status: 200, body: JSON.generate([]), headers: {})
         cert = Purest::Cert.update(self_signed: true, common_name: 'host.example.com', state: 'FL')
+      end
+    end
+  end
+  describe '#delete' do
+    context 'when creating a self signed certificate' do
+      it 'puts to the correct URL with some cool params' do
+        stub_request(:delete, "#{Purest.configuration.url}/api/1.11/cert/new_cert")
+          .with(
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'User-Agent' => 'Faraday v0.15.2'
+            }
+          )
+          .to_return(status: 200, body: JSON.generate([]), headers: {})
+        cert = Purest::Cert.delete(name: 'new_cert')
       end
     end
   end

--- a/spec/integration/cert_spec.rb
+++ b/spec/integration/cert_spec.rb
@@ -22,5 +22,17 @@ describe Purest::Cert, integration: true do
         end
       end
     end
+    context 'when deleting a cert' do
+      API_VERSIONS.each do |version|
+        it "creates and deletes a cert on api version #{version}" do
+          Purest.configuration.api_version = version
+          cert = Purest::Cert.create(name: 'integration-tester-cert', self_signed: true, state: 'WY')
+          Purest::Cert.delete(name: 'integration-tester-cert')
+
+          non_existent_cert = Purest::Cert.get(name: 'integration-tester-cert')
+          expect(non_existent_cert.first[:msg]).to eq('Certificate does not exist')
+        end
+      end
+    end
   end
 end

--- a/spec/integration/cert_spec.rb
+++ b/spec/integration/cert_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Purest::Cert, integration: true do
+  describe '#post' do
+    before(:each) do
+      WebMock.allow_net_connect!
+      Purest.configuration.url = INTEGRATION['url']
+      Purest.configuration.username = INTEGRATION['username']
+      Purest.configuration.password = INTEGRATION['password']
+    end
+    context 'when creating a cert' do
+      API_VERSIONS.each do |version|
+        Purest.configuration.api_version = version
+        it "actually creates a cert on api version #{version}" do
+          cert = Purest::Cert.create(name: 'integration-tester-cert', self_signed: true, state: 'WY')
+          fetched_cert = Purest::Cert.get(name: 'integration-tester-cert')
+
+          binding.pry
+          expect(fetched_cert[:name]).to eq(cert[:name])
+          Purest::Cert.delete(name: 'integration-tester-cert')
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/cert_spec.rb
+++ b/spec/integration/cert_spec.rb
@@ -12,13 +12,12 @@ describe Purest::Cert, integration: true do
     end
     context 'when creating a cert' do
       API_VERSIONS.each do |version|
-        Purest.configuration.api_version = version
         it "actually creates a cert on api version #{version}" do
+          Purest.configuration.api_version = version
           cert = Purest::Cert.create(name: 'integration-tester-cert', self_signed: true, state: 'WY')
           fetched_cert = Purest::Cert.get(name: 'integration-tester-cert')
 
-          binding.pry
-          expect(fetched_cert[:name]).to eq(cert[:name])
+          expect(fetched_cert[:state]).to eq('WY')
           Purest::Cert.delete(name: 'integration-tester-cert')
         end
       end

--- a/spec/integration/host_group_spec.rb
+++ b/spec/integration/host_group_spec.rb
@@ -12,8 +12,8 @@ describe Purest::HostGroup, integration: true do
     end
     context 'when getting performance about a hostgroup' do
       API_VERSIONS.each do |version|
-        Purest.configuration.api_version = version
         it "actually gets hostgroup information on api version #{version}" do
+          Purest.configuration.api_version = version
           host_group = Purest::HostGroup.create(name: 'integration-tester-hgroup')
           host_group_fetched = Purest::HostGroup.get(name: 'integration-tester-hgroup', action: 'monitor')
 
@@ -27,8 +27,8 @@ describe Purest::HostGroup, integration: true do
     end
     context 'when creating a hostgroup' do
       API_VERSIONS.each do |version|
-        Purest.configuration.api_version = version
         it "actually creates a hostgroup on api version #{version}" do
+          Purest.configuration.api_version = version
           host_group = Purest::HostGroup.create(name: 'integration-tester-hgroup')
           host_group_fetched = Purest::HostGroup.get(name: 'integration-tester-hgroup')
           expect(host_group_fetched[:name]).to eq('integration-tester-hgroup')
@@ -39,8 +39,8 @@ describe Purest::HostGroup, integration: true do
     end
     context 'when updating a hostgroup' do
       API_VERSIONS.each do |version|
-        Purest.configuration.api_version = version
         it "actually creates a hostgroup on api version #{version}" do
+          Purest.configuration.api_version = version
           Purest::HostGroup.delete(name: 'integration-tester-hgroup')
           host_group = Purest::HostGroup.create(name: 'integration-tester-hgroup')
           host_group_updated = Purest::HostGroup.update(name: 'integration-tester-hgroup', new_name: 'integration-tester-hgroup-renamed')

--- a/spec/integration/host_spec.rb
+++ b/spec/integration/host_spec.rb
@@ -12,8 +12,8 @@ describe Purest::Host, integration: true do
     end
     context 'when creating a host' do
       API_VERSIONS.each do |version|
-        Purest.configuration.api_version = version
         it "actually creates a host on api version #{version}" do
+          Purest.configuration.api_version = version
           host = Purest::Host.create(name: 'integration-tester-host')
           fetched_host = Purest::Host.get(name: 'integration-tester-host')
 
@@ -32,8 +32,8 @@ describe Purest::Host, integration: true do
     end
     context 'when updating a host' do
       API_VERSIONS.each do |version|
-        Purest.configuration.api_version = version
         it "actually renames a host on api version #{version}" do
+          Purest.configuration.api_version = version
           host = Purest::Host.create(name: 'integration-tester-host')
           host_renamed = Purest::Host.update(name: 'integration-tester-host', new_name: 'integration-tester-host-renamed')
           fetched_renamed_host = Purest::Host.get(name: host_renamed[:name])


### PR DESCRIPTION
This branch does the following:

- Ensures the Cert class can utilize the functionality of the /cert endpoint, introduced in 1.12.

- Introduces two new methods for the Cert class, .create and .delete

- Adds integration specs for the cert class, ensuring a certificate can be created and deleted.